### PR TITLE
Support discard uploaded file or loaded text function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ This driver initially targets the Mellanox device with Onyx OS though other, sim
 * get_lldp_neighbors
 * is_alive
 * cli
+* discard_config


### PR DESCRIPTION
Support discard uploaded file or loaded text function

discard_config: delete config from the remote or just flush the candidate temp. text.