### PR TITLE
support commit the merged file or candidate text

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ This driver initially targets the Mellanox device with Onyx OS though other, sim
 * get_lldp_neighbors
 * is_alive
 * cli
+* commit_merge

--- a/napalm_onyx/onyx_ssh.py
+++ b/napalm_onyx/onyx_ssh.py
@@ -377,7 +377,7 @@ class ONYXSSHDriver(NetworkDriver):
             output = self.device.send_config_set(commands)
         except Exception as e:
             raise MergeConfigException(str(e))
-        if 'Invalid command' in output:
+        if '%' in output:
             raise MergeConfigException('Error while applying config!')
         # clear the merge buffer
         self.merge_candidate = ''
@@ -398,6 +398,10 @@ class ONYXSSHDriver(NetworkDriver):
             raise ReplaceConfigException(rollback_result)
         elif rollback_result == []:
             raise ReplaceConfigException
+
+    def commit_merge(self):
+        """Apply the candidate configration on the switch and do merge."""
+        self._commit_merge()
 
     def _delete_file(self, filename):
         commands = [


### PR DESCRIPTION
support commit_merge file or candidate text

commit_config: run the candidate file/text on the switch.