### PR TITLE
Implement force_no_enable attribute

### DIFF
--- a/napalm_onyx/onyx_ssh.py
+++ b/napalm_onyx/onyx_ssh.py
@@ -146,6 +146,7 @@ class ONYXSSHDriver(NetworkDriver):
         self.merge_candidate = ''
         self.netmiko_optional_args = netmiko_args(optional_args)
         self.device = None
+        self.force_no_enable = optional_args.get("force_no_enable", False)
 
     def open(self):
         self.device = self._netmiko_open(


### PR DESCRIPTION
To be compatible with Napalm 3.0.0, objects require a `self.force_no_enable` attribute - see https://github.com/napalm-automation/napalm/pull/984